### PR TITLE
Add low battery notifications, improve device detection fallback by name, and fix tray icon rendering

### DIFF
--- a/Cloud2BatteryMonitorUI/MainForm.cpp
+++ b/Cloud2BatteryMonitorUI/MainForm.cpp
@@ -30,14 +30,50 @@ std::string getHeadsetDevicePath()
 	}
 
 	if (devices == NULL) {
-		return ""; // Nothing found
+		// Fallback: find a supported headset by name, then re-enumerate by VID/PID
+		struct hid_device_info* allDevices = hid_enumerate(0, 0);
+
+		unsigned short foundVID = 0;
+		unsigned short foundPID = 0;
+
+		for (struct hid_device_info* current = allDevices; current != nullptr; current = current->next)
+		{
+			if ((current->vendor_id == HEADSET_VENDOR_ID_HP || current->vendor_id == HEADSET_VENDOR_ID_KINGSTON) &&
+				current->product_string != nullptr &&
+				(wcsstr(current->product_string, L"Cloud II Wireless") != 0 ||
+					wcsstr(current->product_string, L"Cloud Stinger 2 Wireless") != 0 ||
+					wcsstr(current->product_string, L"Cloud II Core") != 0 ||
+					wcsstr(current->product_string, L"Cloud Alpha Wireless") != 0 ||
+					wcsstr(current->product_string, L"Cloud III S Wireless") != 0 ||
+					wcsstr(current->product_string, L"Cloud III Wireless") != 0))
+			{
+				foundVID = current->vendor_id;
+				foundPID = current->product_id;
+				break;
+			}
+		}
+
+		hid_free_enumeration(allDevices);
+
+		if (foundVID == 0) {
+			return ""; // Nothing found
+		}
+
+		// Rebuild devices list using VID/PID (same behavior as original logic)
+		devices = hid_enumerate(foundVID, foundPID);
+
+		if (devices == NULL) {
+			return ""; // Safety check
+		}
 	}
 
 	std::string foundPath = "";
 
 	// Special case for hyperx cloud iii S
 	// the 'highest usage' method used below is not applicable here
-	for (struct hid_device_info* current = devices; current != nullptr && current->vendor_id == HEADSET_VENDOR_ID_HP && current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_S; current = current->next)
+	for (struct hid_device_info* current = devices; current != nullptr && current->vendor_id == HEADSET_VENDOR_ID_HP &&
+		(current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_S || (current->product_string != nullptr && wcsstr(current->product_string, L"Cloud III S Wireless") != 0)); 
+		current = current->next)
 	{
 		//looks like the correct condition is usage_page 448 and usage 1 combination
 		if (current->usage_page == 448 && current->usage == 1)
@@ -50,7 +86,9 @@ std::string getHeadsetDevicePath()
 
 	// Special case for HyperX Cloud III Wireless
 	// the 'highest usage' method used below is not applicable here either
-	for (struct hid_device_info* current = devices; current != nullptr && current->vendor_id == HEADSET_VENDOR_ID_HP && (current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_REV4106 || current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_REV4109); current = current->next)
+	for (struct hid_device_info* current = devices; current != nullptr && current->vendor_id == HEADSET_VENDOR_ID_HP &&
+		(current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_REV4106 || current->product_id == HEADSET_PRODUCT_ID_HP_CLOUD_III_REV4109 || (current->product_string != nullptr && wcsstr(current->product_string, L"Cloud III Wireless") != 0)); 
+		current = current->next)
 	{
 		// From log: the correct interface is usage_page 65299 and usage 1
 		if (current->usage_page == 65299 && current->usage == 1)

--- a/Cloud2BatteryMonitorUI/MainForm.h
+++ b/Cloud2BatteryMonitorUI/MainForm.h
@@ -37,13 +37,17 @@ namespace Cloud2BatteryMonitorUI {
 	/// <summary>
 	/// Summary for MainForm
 	/// </summary>
-	public ref class MainForm : public System::Windows::Forms::Form
-	{
-	public:
-		System::Windows::Forms::Timer^ timerRefresh = gcnew System::Windows::Forms::Timer();
+		public ref class MainForm : public System::Windows::Forms::Form
+		{
+		public:
+			System::Windows::Forms::Timer^ timerRefresh = gcnew System::Windows::Forms::Timer();
+			bool lowBatteryPopupShown = false;
 
 		//a variable to hold offline icon permanently
 		System::Drawing::Icon^ defaultOfflineIcon;
+
+		//holds the currently generated tray icon so it can be disposed safely on refresh
+		System::Drawing::Icon^ currentTrayGeneratedIcon = nullptr;
 
 		MainForm(void)
 		{
@@ -65,6 +69,13 @@ namespace Cloud2BatteryMonitorUI {
 			if (components)
 			{
 				delete components;
+			}
+
+			//dispose of the current generated tray icon if it exists
+			if (currentTrayGeneratedIcon != nullptr)
+			{
+				delete currentTrayGeneratedIcon;
+				currentTrayGeneratedIcon = nullptr;
 			}
 
 			//dispose of the cached offline icon when the app closes
@@ -324,13 +335,31 @@ namespace Cloud2BatteryMonitorUI {
 		{
 			hid_device* headsetDevice = hid_open_path(devicePath.c_str());
 
-			if (headsetDevice != NULL) 
-			{
-				int batteryLevel = getBatteryLevel(headsetDevice);
-
-				// If the app is minized, only refresh the icon.
-				if (this->WindowState != FormWindowState::Minimized) 
+				if (headsetDevice != NULL) 
 				{
+					int batteryLevel = getBatteryLevel(headsetDevice);
+					SettingsHelper* settingsHelper = new SettingsHelper();
+
+					if (settingsHelper->getLowBatteryPopupEnabled() &&
+						batteryLevel > 0 &&
+						batteryLevel <= settingsHelper->getLowBatteryPopupLevel())
+					{
+						if (!lowBatteryPopupShown)
+						{
+							this->iconSystemTray->BalloonTipTitle = "Battery monitor";
+							this->iconSystemTray->BalloonTipText = "Battery level low: " + batteryLevel + "%";
+							this->iconSystemTray->ShowBalloonTip(5000);
+							lowBatteryPopupShown = true;
+						}
+					}
+					else
+					{
+						lowBatteryPopupShown = false;
+					}
+
+					// If the app is minized, only refresh the icon.
+					if (this->WindowState != FormWindowState::Minimized) 
+					{
 					wchar_t manufacturer[20];
 					hid_get_manufacturer_string(headsetDevice, manufacturer, 20);
 					wchar_t productName[50];
@@ -362,31 +391,34 @@ namespace Cloud2BatteryMonitorUI {
 				wchar_t productName[50];
 				hid_get_product_string(headsetDevice, productName, 50);
 
-				System::String^ batStr2 = gcnew System::String(to_string(batteryLevel).c_str());
-				System::String^ prodStr = gcnew System::String(productName);
-				RefreshTrayIcon(batStr2, prodStr);
-				
-				//close the connection only if it was opened.
-				hid_close(headsetDevice);
+					System::String^ batStr2 = gcnew System::String(to_string(batteryLevel).c_str());
+					System::String^ prodStr = gcnew System::String(productName);
+					RefreshTrayIcon(batStr2, prodStr);
+					delete settingsHelper;
+					
+					//close the connection only if it was opened.
+					hid_close(headsetDevice);
 
 			}
 			else 
 			{
 				this->iconSystemTray->Text = NO_DEVICE_STRING;
 				//use loaded offline icon
-				this->iconSystemTray->Icon = defaultOfflineIcon;
-				this->lbStatus->Text = "Could not connect to headset.";
-				this->btnRefresh->Visible = true;
+					this->iconSystemTray->Icon = defaultOfflineIcon;
+					this->lbStatus->Text = "Could not connect to headset.";
+					this->btnRefresh->Visible = true;
+					lowBatteryPopupShown = false;
+				}
 			}
-		}
-		else 
+			else 
 		{
 			this->iconSystemTray->Text = NO_DEVICE_STRING;
 			//use loaded offline icon
-			this->iconSystemTray->Icon = defaultOfflineIcon;
-			this->lbStatus->Text = "No headset device detected.";
-			this->btnRefresh->Visible = true;
-		}
+				this->iconSystemTray->Icon = defaultOfflineIcon;
+				this->lbStatus->Text = "No headset device detected.";
+				this->btnRefresh->Visible = true;
+				lowBatteryPopupShown = false;
+			}
 
 		if (timerRefresh->Enabled == false) 
 		{
@@ -455,10 +487,22 @@ namespace Cloud2BatteryMonitorUI {
 				hIcon = RefreshTrayNumber(batteryLevel, settingsHelper);
 			}
 
-			//apply icon
-			this->iconSystemTray->Icon = System::Drawing::Icon::FromHandle(hIcon);
+			//dispose of the previous generated tray icon before creating a new one
+			if (currentTrayGeneratedIcon != nullptr)
+			{
+				delete currentTrayGeneratedIcon;
+				currentTrayGeneratedIcon = nullptr;
+			}
 
-			//destroy the unmanaged handle!
+			//create a temporary wrapper from the unmanaged handle,
+			//clone it so the tray owns a safe managed copy,
+			//then destroy the original unmanaged handle
+			System::Drawing::Icon^ tempIcon = System::Drawing::Icon::FromHandle(hIcon);
+			currentTrayGeneratedIcon = safe_cast<System::Drawing::Icon^>(tempIcon->Clone());
+
+			this->iconSystemTray->Icon = currentTrayGeneratedIcon;
+
+			delete tempIcon;
 			DestroyIcon(hIcon);
 
 			trayText += BATTERY_LEVEL_STRING + batteryLevel + "%";
@@ -467,6 +511,13 @@ namespace Cloud2BatteryMonitorUI {
 		else
 		{
 			trayText += BATTERY_LEVEL_STRING + "N/A";
+
+			//dispose of the previous generated tray icon when switching to offline icon
+			if (currentTrayGeneratedIcon != nullptr)
+			{
+				delete currentTrayGeneratedIcon;
+				currentTrayGeneratedIcon = nullptr;
+			}
 
 			//use loaded offline icon
 			this->iconSystemTray->Icon = defaultOfflineIcon;

--- a/Cloud2BatteryMonitorUI/SettingsForm.h
+++ b/Cloud2BatteryMonitorUI/SettingsForm.h
@@ -52,6 +52,8 @@ namespace Cloud2BatteryMonitorUI {
 	private: System::Windows::Forms::Label^ lbRefresh;
 	private: System::Windows::Forms::NumericUpDown^ numRefreshMinutes;
 	private: System::Windows::Forms::CheckBox^ cbBatIcon;
+	private: System::Windows::Forms::CheckBox^ cbLowBatteryPopup;
+	private: System::Windows::Forms::NumericUpDown^ numLowBatteryPopup;
 
 	private:
 		/// <summary>
@@ -81,10 +83,13 @@ namespace Cloud2BatteryMonitorUI {
 			this->lbBackground = (gcnew System::Windows::Forms::Label());
 			this->lbText = (gcnew System::Windows::Forms::Label());
 			this->lbRefresh = (gcnew System::Windows::Forms::Label());
-			this->numRefreshMinutes = (gcnew System::Windows::Forms::NumericUpDown());
-			this->cbBatIcon = (gcnew System::Windows::Forms::CheckBox());
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numRefreshMinutes))->BeginInit();
-			this->SuspendLayout();
+				this->numRefreshMinutes = (gcnew System::Windows::Forms::NumericUpDown());
+				this->cbBatIcon = (gcnew System::Windows::Forms::CheckBox());
+				this->cbLowBatteryPopup = (gcnew System::Windows::Forms::CheckBox());
+				this->numLowBatteryPopup = (gcnew System::Windows::Forms::NumericUpDown());
+				(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numRefreshMinutes))->BeginInit();
+				(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numLowBatteryPopup))->BeginInit();
+				this->SuspendLayout();
 			// 
 			// lbSettingsHigh
 			// 
@@ -261,15 +266,39 @@ namespace Cloud2BatteryMonitorUI {
 			this->cbBatIcon->TabIndex = 21;
 			this->cbBatIcon->Text = L"Use battery as icon.";
 			this->cbBatIcon->UseVisualStyleBackColor = true;
-			this->cbBatIcon->CheckStateChanged += gcnew System::EventHandler(this, &SettingsForm::CBBatIcon_CheckChange);
-			// 
-			// SettingsForm
-			// 
+				this->cbBatIcon->CheckStateChanged += gcnew System::EventHandler(this, &SettingsForm::CBBatIcon_CheckChange);
+				// 
+				// cbLowBatteryPopup
+				// 
+				this->cbLowBatteryPopup->AutoSize = true;
+				this->cbLowBatteryPopup->Location = System::Drawing::Point(165, 150);
+				this->cbLowBatteryPopup->Name = L"cbLowBatteryPopup";
+				this->cbLowBatteryPopup->Size = System::Drawing::Size(107, 17);
+				this->cbLowBatteryPopup->TabIndex = 22;
+				this->cbLowBatteryPopup->Text = L"Low battery popup";
+				this->cbLowBatteryPopup->UseVisualStyleBackColor = true;
+				// 
+				// numLowBatteryPopup
+				// 
+				this->numLowBatteryPopup->BackColor = System::Drawing::Color::LightGray;
+				this->numLowBatteryPopup->BorderStyle = System::Windows::Forms::BorderStyle::FixedSingle;
+				this->numLowBatteryPopup->Location = System::Drawing::Point(278, 149);
+				this->numLowBatteryPopup->Maximum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 99, 0, 0, 0 });
+				this->numLowBatteryPopup->Minimum = System::Decimal(gcnew cli::array< System::Int32 >(4) { 1, 0, 0, 0 });
+				this->numLowBatteryPopup->Name = L"numLowBatteryPopup";
+				this->numLowBatteryPopup->Size = System::Drawing::Size(32, 20);
+				this->numLowBatteryPopup->TabIndex = 23;
+				this->numLowBatteryPopup->Value = System::Decimal(gcnew cli::array< System::Int32 >(4) { 20, 0, 0, 0 });
+				// 
+				// SettingsForm
+				// 
 			this->AutoScaleDimensions = System::Drawing::SizeF(6, 13);
 			this->AutoScaleMode = System::Windows::Forms::AutoScaleMode::Font;
 			this->BackColor = System::Drawing::Color::Silver;
-			this->ClientSize = System::Drawing::Size(316, 209);
-			this->Controls->Add(this->cbBatIcon);
+				this->ClientSize = System::Drawing::Size(316, 209);
+				this->Controls->Add(this->numLowBatteryPopup);
+				this->Controls->Add(this->cbLowBatteryPopup);
+				this->Controls->Add(this->cbBatIcon);
 			this->Controls->Add(this->numRefreshMinutes);
 			this->Controls->Add(this->lbRefresh);
 			this->Controls->Add(this->lbText);
@@ -291,10 +320,11 @@ namespace Cloud2BatteryMonitorUI {
 			this->MinimumSize = System::Drawing::Size(332, 248);
 			this->Name = L"SettingsForm";
 			this->Text = L"Settings";
-			this->Load += gcnew System::EventHandler(this, &SettingsForm::SettingsForm_Load);
-			(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numRefreshMinutes))->EndInit();
-			this->ResumeLayout(false);
-			this->PerformLayout();
+				this->Load += gcnew System::EventHandler(this, &SettingsForm::SettingsForm_Load);
+				(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numRefreshMinutes))->EndInit();
+				(cli::safe_cast<System::ComponentModel::ISupportInitialize^>(this->numLowBatteryPopup))->EndInit();
+				this->ResumeLayout(false);
+				this->PerformLayout();
 
 		}
 #pragma endregion
@@ -315,8 +345,15 @@ namespace Cloud2BatteryMonitorUI {
 		this->btnMedText->BackColor = settingsHelper->getColorMedText();
 		this->btnLow->BackColor = settingsHelper->getColorLow();
 		this->btnLowText->BackColor = settingsHelper->getColorLowText();
-		this->cbStart->Checked = settingsHelper->getAutostart();
-		this->cbBatIcon->Checked = settingsHelper->getBatIcon();
+			this->cbStart->Checked = settingsHelper->getAutostart();
+			this->cbBatIcon->Checked = settingsHelper->getBatIcon();
+			this->cbLowBatteryPopup->Checked = settingsHelper->getLowBatteryPopupEnabled();
+			int lowBatteryLevel = settingsHelper->getLowBatteryPopupLevel();
+			if (lowBatteryLevel < 1 || lowBatteryLevel > 99)
+			{
+				lowBatteryLevel = 20;
+			}
+			this->numLowBatteryPopup->Value = lowBatteryLevel;
 
 		if (cbBatIcon->Checked)
 		{
@@ -367,8 +404,10 @@ namespace Cloud2BatteryMonitorUI {
 		settingsHelper->setColorMedText(this->btnMedText->BackColor);
 		settingsHelper->setColorLow(this->btnLow->BackColor);
 		settingsHelper->setColorLowText(this->btnLowText->BackColor);
-		settingsHelper->setAutostart(this->cbStart->Checked);
-		settingsHelper->setBatIcon(this->cbBatIcon->Checked);
+			settingsHelper->setAutostart(this->cbStart->Checked);
+			settingsHelper->setBatIcon(this->cbBatIcon->Checked);
+			settingsHelper->setLowBatteryPopupEnabled(this->cbLowBatteryPopup->Checked);
+			settingsHelper->setLowBatteryPopupLevel((int)this->numLowBatteryPopup->Value);
 
 		settingsHelper->saveSettings();
 

--- a/Cloud2BatteryMonitorUI/SettingsHelper.cpp
+++ b/Cloud2BatteryMonitorUI/SettingsHelper.cpp
@@ -153,3 +153,45 @@ void SettingsHelper::setBatIcon(bool useBatIcon)
         batNode.text().set(useBatIcon);
     }
 }
+
+bool SettingsHelper::getLowBatteryPopupEnabled()
+{
+    return settingsNode.find_child_by_attribute(XML_ELEM_SETTING, XML_ATTR_NAME, "lowBatteryPopupEnabled").text().as_bool();
+}
+
+void SettingsHelper::setLowBatteryPopupEnabled(bool enabled)
+{
+    pugi::xml_node popupNode = settingsNode.find_child_by_attribute(XML_ELEM_SETTING, XML_ATTR_NAME, "lowBatteryPopupEnabled");
+    if (!popupNode)
+    {
+        pugi::xml_node newNode = settingsNode.append_child("setting");
+        pugi::xml_attribute attribute = newNode.append_attribute("name");
+        attribute.set_value("lowBatteryPopupEnabled");
+        newNode.text().set(enabled);
+    }
+    else
+    {
+        popupNode.text().set(enabled);
+    }
+}
+
+int SettingsHelper::getLowBatteryPopupLevel()
+{
+    return settingsNode.find_child_by_attribute(XML_ELEM_SETTING, XML_ATTR_NAME, "lowBatteryPopupLevel").text().as_int();
+}
+
+void SettingsHelper::setLowBatteryPopupLevel(int level)
+{
+    pugi::xml_node levelNode = settingsNode.find_child_by_attribute(XML_ELEM_SETTING, XML_ATTR_NAME, "lowBatteryPopupLevel");
+    if (!levelNode)
+    {
+        pugi::xml_node newNode = settingsNode.append_child("setting");
+        pugi::xml_attribute attribute = newNode.append_attribute("name");
+        attribute.set_value("lowBatteryPopupLevel");
+        newNode.text().set(level);
+    }
+    else
+    {
+        levelNode.text().set(level);
+    }
+}

--- a/Cloud2BatteryMonitorUI/SettingsHelper.h
+++ b/Cloud2BatteryMonitorUI/SettingsHelper.h
@@ -38,5 +38,9 @@ public:
     void setAutostart(bool);
     bool getBatIcon();
     void setBatIcon(bool);
+    bool getLowBatteryPopupEnabled();
+    void setLowBatteryPopupEnabled(bool);
+    int getLowBatteryPopupLevel();
+    void setLowBatteryPopupLevel(int);
 
 };

--- a/Cloud2BatteryMonitorUI/settings.xml
+++ b/Cloud2BatteryMonitorUI/settings.xml
@@ -9,4 +9,6 @@
 	<setting name="colorLowText">-1</setting>
 	<setting name="refreshMinutes">5</setting>
 	<setting name="batteryIcon">false</setting>
+	<setting name="lowBatteryPopupEnabled">false</setting>
+	<setting name="lowBatteryPopupLevel">20</setting>
 </settings>


### PR DESCRIPTION
**Motivation**

1. Provide an optional low-battery balloon notification so users can be alerted when headset battery is low.
2. Expose configuration for enabling the popup and setting the threshold from the existing Settings UI and persisted settings file.
3. Improve device detection reliability by adding a fallback mechanism to identify supported headsets by product name when Product IDs change due to firmware updates.
4. Fix an intermittent issue where the system tray icon could appear blank on some systems due to icon handle lifetime management.


Description

1. Added a lowBatteryPopupShown flag and logic in MainForm to show a single balloon tip when the battery level is non-zero and at-or-below the configured threshold, and reset the flag when appropriate in disconnected/no-device states.
2. Added UI controls to SettingsForm (cbLowBatteryPopup and numLowBatteryPopup) and wired them to load/save settings via SettingsHelper so users can enable the popup and set the percentage threshold.
3. Extended SettingsHelper (SettingsHelper.h / SettingsHelper.cpp) with:
- getLowBatteryPopupEnabled
- setLowBatteryPopupEnabled
- getLowBatteryPopupLevel
- setLowBatteryPopupLevel
to persist the new settings.


4. Added default values for the new settings to settings.xml and cleaned up object lifetime management where SettingsHelper instances are created and deleted.
5. Improved headset detection robustness by adding a fallback detection path in getHeadsetDevicePath() that:
-Enumerates all HID devices
-Identifies supported headsets by vendor ID and product name
- Re-enumerates using the detected VID/PID
-This ensures compatibility with devices where firmware updates change Product IDs while keeping the product name consistent.

6. Extended special-case detection logic for Cloud III Wireless and Cloud III S Wireless to also validate the product string in addition to Product ID, improving resilience against firmware revisions.
7. Fixed a system tray icon rendering issue by improving icon lifetime management:
-Generated tray icons are now cloned into managed Icon instances before destroying the underlying unmanaged HICON
- Added tracking and disposal of previously generated tray icons to prevent managed/GDI resource leaks
- Preserved the existing fix for unmanaged handle leaks while ensuring the tray icon remains valid for asynchronous shell rendering